### PR TITLE
Added port mapping 4000:4000 to docker installation instructions

### DIFF
--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -54,6 +54,8 @@ services:
       LOCAL_LEDGER_SECRET_KEY: "<local_ledger_secret_key_here>"
       SMTP_HOST: mailhog
       SMTP_PORT: 1025
+    ports:
+      - 4000:4000
 
 networks:
   external:


### PR DESCRIPTION
Issue/Task Number: #399

# Overview
This PR adds port mapping to the Docker-compose instruction file, as it gives an address already in use error without this. 

# Changes
- Added ports 4000:4000